### PR TITLE
ドロップ判定をポインター位置ベースに変更

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {
   DndContext,
   DragOverlay,
-  closestCenter,
+  pointerWithin,
   PointerSensor,
   TouchSensor,
   useSensor,
@@ -470,7 +470,7 @@ https://gghatano.github.io/vegetable-ranking/`;
   return (
     <DndContext
       sensors={sensors}
-      collisionDetection={closestCenter}
+      collisionDetection={pointerWithin}
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}


### PR DESCRIPTION
- collisionDetectionをclosestCenterからpointerWithinに変更
- ドラッグハンドルを掴んでいる指/カーソルの位置で判定されるように