### PR TITLE
コメント欄のplaceholderを改善して理由記入を誘導

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -163,7 +163,7 @@ const SortableVeggieCard = ({ veggie, comments, updateComment }) => {
         </div>
         <input
           type="text"
-          placeholder="コメント"
+          placeholder="選んだ理由を一言..."
           value={comments[veggie] || ''}
           onChange={(e) => updateComment(veggie, e.target.value)}
           className="w-full text-xs md:text-sm px-2 py-1 mt-1 border border-gray-200 rounded focus:outline-none focus:border-green-400"
@@ -226,7 +226,7 @@ const RankingSlot = ({ index, veggie, comments, updateComment, removeFromRanking
               </button>
             </div>
             <textarea
-              placeholder="コメント"
+              placeholder="選んだ理由を一言..."
               value={comments[veggie] || ''}
               onChange={(e) => updateComment(veggie, e.target.value)}
               className="w-full text-xs lg:text-sm px-1 lg:px-2 py-1 mt-1 border border-gray-200 rounded resize-none focus:outline-none focus:border-green-500 bg-white hidden lg:block"


### PR DESCRIPTION
## Summary
- コメント欄のplaceholderを「コメント」から「選んだ理由を一言...」に変更
- ユーザーが野菜を選んだ理由を書くように誘導

Closes #14

## Test plan
- [ ] 野菜リスト内のコメント入力欄でplaceholderが「選んだ理由を一言...」と表示される
- [ ] ランキングスロット内のコメント入力欄でplaceholderが「選んだ理由を一言...」と表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)